### PR TITLE
Use markdown for `README` and contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+If you wish to contribute to Cynosure, please adhere to the following formatting guidelines:
+
+- No lines of code longer than 80 characters.
+- Indent your code with 2 spaces. Please don't use tabs.
+- If creating a new kernel source file, base it on `src/template.lua` so you get the copyright notice and whatnot.
+- If modifying an existing source file, add your name to the list at the top of the file.

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -1,8 +1,0 @@
-// contributing
-
-If you wish to contribute to Cynosure, please adhere to the following formatting guidelines:
-
- - No lines of code longer than 80 characters.
- - Indent your code with 2 spaces. Please don't use tabs.
- - If creating a new kernel source file, base it on `src/template.lua` so you get the copyright notice and whatnot.
- - If modifying an existing source file, add your name to the list at the top of the file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-CYNOSURE 2.0
-============
-
+# CYNOSURE 2.0
 This is the second major release of Cynosure.  Much of it has been rewritten, providing a more POSIX-like experience all around.  However, it maintains the same goals of speed, stability, and completeness.
 
 Cynosure 2.0 is not designed to be lightweight on memory.


### PR DESCRIPTION
Potential discussion: replace `CYNOSURE 2.0` in readme with `Cynosure 2.0`?